### PR TITLE
Fix incorrect status code for empty predictions endpoint

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -26,17 +26,18 @@ def test():
     """
     return {"message": "Hello World, this is a test!"}
 
-@app.post("/getall")
+@app.get("/getall")
 def get_all_preds(db=Depends(db)):
     """
-    Endpoint to get all the predictions in the 
+    Endpoint to get all the predictions in the
     database as a list.
     """
     preds = get_predictions(db)
     if preds:
         return preds
     else:
-        raise HTTPException(status_code=200, detail='No preds found in the database.')
+        # Return a 404 status code when no predictions are found
+        raise HTTPException(status_code=404, detail='No preds found in the database.')
 
 @app.post("/predict")
 def predict_segment(data: CustomerData,db = Depends(db)):

--- a/tests/test_get_all.py
+++ b/tests/test_get_all.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+# Ensure the project root is importable so `src` can be found
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+# Set environment variables before importing the app
+os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+os.environ["MODEL_PATH"] = "data/model.pkl"
+
+from fastapi.testclient import TestClient
+from src.api import app
+from src.database import engine
+from src.models import Base
+
+# Ensure the database is empty
+Base.metadata.drop_all(bind=engine)
+Base.metadata.create_all(bind=engine)
+
+client = TestClient(app)
+
+
+def test_get_all_preds_empty_returns_404():
+    response = client.get("/getall")
+    assert response.status_code == 404
+    assert response.json() == {"detail": "No preds found in the database."}


### PR DESCRIPTION
## Summary
- use GET for `/getall` endpoint and return 404 when no predictions exist
- add regression test for empty predictions list

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a61d8b4f248331b662e21ba49d5499